### PR TITLE
Notification bug fix

### DIFF
--- a/src/Scheduled/NotificationSystem.cs
+++ b/src/Scheduled/NotificationSystem.cs
@@ -38,6 +38,7 @@ namespace WaterBot.Scheduled
                 foreach (UserData data in enumerable)
                 {
                     if (!data.ReminderEnabled) continue;
+                    if (now < data.WakeTime && now > data.SleepTime) continue;
 
                     try
                     {
@@ -52,14 +53,15 @@ namespace WaterBot.Scheduled
                                 $"Hey! it's time to drink {data.AmountPerInterval}mL of water to stay hydrated! :droplet:");
                                 data.LatestReminder = UserData.CalculateLatestReminder(data.RemindersList, now);
                                 UserDataManager.SaveData(data);
+                                break;
                             }
-                            else if (timeSpan == data.RemindersList.First() && data.LatestReminder == data.RemindersList.Last() && timeSpan < now && timeSpan < data.LatestReminder)
-                            {
-                                await user.SendMessageAsync(
-                                    $"Hey! it's time to drink {data.AmountPerInterval}mL of water to stay hydrated! :droplet:");
-                                data.LatestReminder = UserData.CalculateLatestReminder(data.RemindersList, now);
-                                UserDataManager.SaveData(data);
-                            }
+
+                            if (timeSpan != data.RemindersList.First() || data.LatestReminder != data.RemindersList.Last() || timeSpan >= now || timeSpan >= data.LatestReminder) continue;
+                            await user.SendMessageAsync(
+                                $"Hey! it's time to drink {data.AmountPerInterval}mL of water to stay hydrated! :droplet:");
+                            data.LatestReminder = UserData.CalculateLatestReminder(data.RemindersList, now);
+                            UserDataManager.SaveData(data);
+                            break;
                         }
                     }
                     catch (Exception exception)


### PR DESCRIPTION
Adding a break after the notification has been sent prevent the user from being notified more than one time in a row.

---

#### Explanation of the bug:
(See the changed file for more context)
```cs
if (timeSpan != data.RemindersList.First() || data.LatestReminder != data.RemindersList.Last() || timeSpan >= now || timeSpan >= data.LatestReminder) continue;

await user.SendMessageAsync(
  $"Hey! it's time to drink {data.AmountPerInterval}mL of water to stay hydrated! :droplet:");
data.LatestReminder = UserData.CalculateLatestReminder(data.RemindersList, now);
UserDataManager.SaveData(data);
break;
```
At the last lines we calculate a new reminder and save it to the JSON file, however this new data is not directly taken into account in the foreach loop, causing the loop to continue until one of the conditions fails.

---
I also added two conditions to prevent notifications during sleep time.