### PR TITLE
Now showing user's profile picture in embed

### DIFF
--- a/src/Commands/ConfigCommandModule.cs
+++ b/src/Commands/ConfigCommandModule.cs
@@ -348,7 +348,7 @@ namespace WaterBot.Commands
                     Description = $"```{nextReminder + data.UtcOffset}```",
                     Color = DiscordColor.CornflowerBlue
                 }
-                .WithAuthor($"{ctx.Member.Username}'s next reminder is at:", ctx.Member.AvatarUrl));
+                .WithAuthor($"{ctx.Member.Username}'s next reminder is at:", iconUrl: ctx.Member.AvatarUrl));
 
         }
     }


### PR DESCRIPTION
This small fix should now properly show the user's icon in the embed which shows the next reminder.